### PR TITLE
Better dpad input handling.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,27 +17,40 @@ static mut ORIG_VIP_TEXT: String = String::new();
 const MAX_INPUT_BUFFER: isize = 25;
 const MIN_INPUT_BUFFER: isize = -1;
 
-unsafe fn handle_user_input() {
-    static mut CURRENT_COUNTER: usize = 0;
+static mut DPAD_RIGHT_RELEASED: bool = true;
+static mut DPAD_LEFT_RELEASED: bool = true;
+static mut DPAD_UP_RELEASED: bool = true;
+static mut DPAD_DOWN_RELEASED: bool = true;
 
-    if ninput::any::is_press(ninput::Buttons::RIGHT) {
-        if CURRENT_COUNTER == 0 {
-            CURRENT_INPUT_BUFFER += 1;
-        }
-        CURRENT_COUNTER = (CURRENT_COUNTER + 1) % 10;
-    } else if ninput::any::is_press(ninput::Buttons::LEFT) {
-        if CURRENT_COUNTER == 0 {
-            CURRENT_INPUT_BUFFER -= 1;
-        }
-        CURRENT_COUNTER = (CURRENT_COUNTER + 1) % 10;
-    } else {
-        CURRENT_COUNTER = 0;
+unsafe fn handle_user_input() {
+    if ninput::any::is_press(ninput::Buttons::RIGHT) && DPAD_RIGHT_RELEASED {
+        CURRENT_INPUT_BUFFER += 1;
+        DPAD_RIGHT_RELEASED = false;
+    } else if ninput::any::is_press(ninput::Buttons::LEFT) && DPAD_LEFT_RELEASED {
+        CURRENT_INPUT_BUFFER -= 1;
+        DPAD_LEFT_RELEASED = false;
     }
 
-    if ninput::any::is_press(ninput::Buttons::UP) {
+    if ninput::any::is_press(ninput::Buttons::UP) && DPAD_UP_RELEASED {
         STEALTH_MODE = true;
-    } else if ninput::any::is_press(ninput::Buttons::DOWN) {
+        DPAD_UP_RELEASED = false;
+    } else if ninput::any::is_press(ninput::Buttons::DOWN) && DPAD_DOWN_RELEASED {
         STEALTH_MODE = false;
+        DPAD_DOWN_RELEASED = false;
+    }
+
+    // Clear button states (ninput is a shit input library lol)
+    if !ninput::any::is_press(ninput::Buttons::RIGHT) {
+        DPAD_RIGHT_RELEASED = true;
+    }
+    if !ninput::any::is_press(ninput::Buttons::LEFT) {
+        DPAD_LEFT_RELEASED = true;
+    }
+    if !ninput::any::is_press(ninput::Buttons::UP) {
+        DPAD_UP_RELEASED = true;
+    }
+    if !ninput::any::is_press(ninput::Buttons::DOWN) {
+        DPAD_DOWN_RELEASED = true;
     }
 
     CURRENT_INPUT_BUFFER = CURRENT_INPUT_BUFFER.clamp(MIN_INPUT_BUFFER, MAX_INPUT_BUFFER);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,40 +17,49 @@ static mut ORIG_VIP_TEXT: String = String::new();
 const MAX_INPUT_BUFFER: isize = 25;
 const MIN_INPUT_BUFFER: isize = -1;
 
-static mut DPAD_RIGHT_RELEASED: bool = true;
-static mut DPAD_LEFT_RELEASED: bool = true;
-static mut DPAD_UP_RELEASED: bool = true;
-static mut DPAD_DOWN_RELEASED: bool = true;
+struct DpadInputState {
+    left_released: bool,
+    right_released: bool,
+    up_released: bool,
+    down_released: bool
+}
+
+static mut DPAD: DpadInputState = DpadInputState {
+    left_released: true,
+    right_released: true,
+    up_released: true,
+    down_released: true
+};
 
 unsafe fn handle_user_input() {
-    if ninput::any::is_press(ninput::Buttons::RIGHT) && DPAD_RIGHT_RELEASED {
+    if ninput::any::is_press(ninput::Buttons::RIGHT) && DPAD.right_released {
         CURRENT_INPUT_BUFFER += 1;
-        DPAD_RIGHT_RELEASED = false;
-    } else if ninput::any::is_press(ninput::Buttons::LEFT) && DPAD_LEFT_RELEASED {
+        DPAD.right_released = false;
+    } else if ninput::any::is_press(ninput::Buttons::LEFT) && DPAD.left_released {
         CURRENT_INPUT_BUFFER -= 1;
-        DPAD_LEFT_RELEASED = false;
+        DPAD.left_released = false;
     }
 
-    if ninput::any::is_press(ninput::Buttons::UP) && DPAD_UP_RELEASED {
+    if ninput::any::is_press(ninput::Buttons::UP) && DPAD.up_released {
         STEALTH_MODE = true;
-        DPAD_UP_RELEASED = false;
-    } else if ninput::any::is_press(ninput::Buttons::DOWN) && DPAD_DOWN_RELEASED {
+        DPAD.up_released = false;
+    } else if ninput::any::is_press(ninput::Buttons::DOWN) && DPAD.down_released {
         STEALTH_MODE = false;
-        DPAD_DOWN_RELEASED = false;
+        DPAD.down_released = false;
     }
 
     // Clear button states (ninput is a shit input library lol)
     if !ninput::any::is_press(ninput::Buttons::RIGHT) {
-        DPAD_RIGHT_RELEASED = true;
+        DPAD.right_released = true;
     }
     if !ninput::any::is_press(ninput::Buttons::LEFT) {
-        DPAD_LEFT_RELEASED = true;
+        DPAD.left_released = true;
     }
     if !ninput::any::is_press(ninput::Buttons::UP) {
-        DPAD_UP_RELEASED = true;
+        DPAD.up_released = true;
     }
     if !ninput::any::is_press(ninput::Buttons::DOWN) {
-        DPAD_DOWN_RELEASED = true;
+        DPAD.down_released = true;
     }
 
     CURRENT_INPUT_BUFFER = CURRENT_INPUT_BUFFER.clamp(MIN_INPUT_BUFFER, MAX_INPUT_BUFFER);


### PR DESCRIPTION
The current way inputs are handled is terrible. This makes it less terrible.

I don't really like my implementation, but the `ninput` library sucks, this was the only way I could get it to work.

Now, 1 input = 1 change to the UI.

---

Unrelated side-note (there's no issue tracker), this mod doesn't work with the training modpack (the training modpack will crash). 
![image](https://github.com/xNaxdy/latency-slider-de/assets/34498340/c0677b2f-6fef-497f-927a-bc5b59e15f61)

If you have any idea of how to fix it, that would be nice. Atm I'm using my own version of the latency mod which has the same functionality as yours, but does not modify text on the CSS (so it can be used in conjunction with the training mod pack).